### PR TITLE
Convert addon for new ayon core

### DIFF
--- a/client/ayon_djv/addon.py
+++ b/client/ayon_djv/addon.py
@@ -1,5 +1,5 @@
 import os
-from openpype.modules import AYONAddon, IPluginPaths
+from ayon_core.addon import AYONAddon, IPluginPaths
 
 from .version import __version__
 from .constants import ADDON_NAME, DJV_ROOT

--- a/client/ayon_djv/plugins/ftrack/open_in_djv.py
+++ b/client/ayon_djv/plugins/ftrack/open_in_djv.py
@@ -1,13 +1,13 @@
 import os
-import time
+
 from operator import itemgetter
 
 from ayon_ftrack.common import LocalAction
 
 from ayon_djv.utils import DJVExecutableCache, get_djv_icon_url
 
-from openpype.lib import run_detached_process
-from openpype.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
+from ayon_core.lib import run_detached_process
+from ayon_core.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 
 
 class DJVViewAction(LocalAction):

--- a/client/ayon_djv/plugins/load/open_in_djv.py
+++ b/client/ayon_djv/plugins/load/open_in_djv.py
@@ -14,7 +14,7 @@ class OpenInDJV(load.LoaderPlugin):
     """Open Image Sequence with system default"""
 
     _executable_cache = DJVExecutableCache()
-    families = ["*"]
+    product_types = ["*"]
     representations = ["*"]
     extensions = {
         ext.lstrip(".")

--- a/client/ayon_djv/plugins/load/open_in_djv.py
+++ b/client/ayon_djv/plugins/load/open_in_djv.py
@@ -3,9 +3,9 @@ import time
 
 import clique
 
-from openpype.lib import run_detached_process
-from openpype.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
-from openpype.pipeline import load
+from ayon_core.lib import run_detached_process
+from ayon_core.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
+from ayon_core.pipeline import load
 
 from ayon_djv.utils import DJVExecutableCache
 


### PR DESCRIPTION
## Description
Changes related to 0.3.0 release of ayon core. All changes happened in client code.

## Additional information
Use `ayon_core` over `openpype`.

## Testing notes
1. Create addon package.
2. Upload to server.
3. Use the addon version in bundle.
4. Run AYON launcher.
5. Both loader and ftrack actions should be working.