### PR TITLE
Adjusts loader action order

### DIFF
--- a/client/ayon_djv/plugins/load/open_in_djv.py
+++ b/client/ayon_djv/plugins/load/open_in_djv.py
@@ -22,7 +22,7 @@ class OpenInDJV(load.LoaderPlugin):
     }
 
     label = "Open in DJV"
-    order = -10
+    order = 0
     icon = "play-circle"
     color = "orange"
 


### PR DESCRIPTION
Changes the order of the 'Open in DJV' loader action to prevent it from taking precedence over other actions.

It moves DJV action below more important ones while having selected anything else than image sequence.
<img width="826" height="444" alt="Screenshot 2025-09-16 171243" src="https://github.com/user-attachments/assets/7c7bbae2-3193-4f02-b2a5-a7711c4a1612" />

